### PR TITLE
Centralize WhatsApp link helper

### DIFF
--- a/src/components/ContactSection.vue
+++ b/src/components/ContactSection.vue
@@ -12,7 +12,7 @@
 
       <div class="max-w-4xl mx-auto">
         <div class="grid md:grid-cols-3 gap-8">
-          <a href="https://wa.me/5511999999999" target="_blank" rel="noopener noreferrer"
+          <a :href="whatsappLink" target="_blank" rel="noopener noreferrer"
             class="block bg-gray-900/50 backdrop-blur-sm border border-amber-500/20 rounded-2xl p-8 text-center hover:border-amber-500/50 transition-all transform hover:scale-105">
             <div class="w-16 h-16 bg-green-500 rounded-full flex items-center justify-center mx-auto mb-6">
               <img src="@/assets/social-media/WhatsApp.svg.png" alt="WhatsApp" class="w-12 h-12" />
@@ -43,6 +43,9 @@
 </template>
 
 <script setup lang="ts">
+import { generateWhatsAppLink } from '@/utils/whatsapp'
+
+const whatsappLink = generateWhatsAppLink('Olá, gostaria de mais informações.')
 </script>
 
 <style scoped></style>

--- a/src/components/FleetSection.vue
+++ b/src/components/FleetSection.vue
@@ -46,6 +46,7 @@ import sentra from '@/assets/fleet/sentra/sentra-1.jpeg'
 import tcross from '@/assets/fleet/t-cros/Tcross-1.jpeg'
 import corolla from '@/assets/fleet/corolla-hybrido-altis/corolla-hybrido.jpeg'
 import type { Vehicle } from './interfaces/fleet.interface'
+import { generateWhatsAppLink } from '@/utils/whatsapp'
 
 const vehicles: Vehicle[] = [
   {
@@ -90,9 +91,7 @@ const vehicles: Vehicle[] = [
   }
 ]
 
-const whatsappNumber = '554191922590'
 function whatsappLink(vehicleName: string): string {
-  const text = encodeURIComponent(`Olá, gostaria de reservar o ${vehicleName}.`)
-  return `https://wa.me/${whatsappNumber}?text=${text}`
+  return generateWhatsAppLink(`Olá, gostaria de reservar o ${vehicleName}.`)
 }
 </script>

--- a/src/utils/whatsapp.ts
+++ b/src/utils/whatsapp.ts
@@ -1,0 +1,6 @@
+export const defaultWhatsAppNumber = '554191922590'
+
+export function generateWhatsAppLink(message: string, phone: string = defaultWhatsAppNumber): string {
+  const encodedMessage = encodeURIComponent(message)
+  return `https://wa.me/${phone}?text=${encodedMessage}`
+}


### PR DESCRIPTION
## Summary
- add helper to build WhatsApp links with default phone number
- use helper in FleetSection and ContactSection

## Testing
- `npm run lint` *(fails: jiti missing)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b56f3c4188329b9342405861808aa