### PR TITLE
Add vue-i18n integration for WhatsApp links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "pinia": "^3.0.1",
         "tailwindcss": "^4.1.10",
         "vue": "^3.5.13",
+        "vue-i18n": "^9.9.0",
         "vue-router": "^4.5.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "pinia": "^3.0.1",
     "tailwindcss": "^4.1.10",
     "vue": "^3.5.13",
+    "vue-i18n": "^9.9.0",
     "vue-router": "^4.5.0"
   },
   "devDependencies": {

--- a/src/components/ContactSection.vue
+++ b/src/components/ContactSection.vue
@@ -45,7 +45,7 @@
 <script setup lang="ts">
 import { generateWhatsAppLink } from '@/utils/whatsapp'
 
-const whatsappLink = generateWhatsAppLink('Olá, gostaria de mais informações.')
+const whatsappLink = generateWhatsAppLink('whatsapp.info')
 </script>
 
 <style scoped></style>

--- a/src/components/FleetSection.vue
+++ b/src/components/FleetSection.vue
@@ -92,6 +92,6 @@ const vehicles: Vehicle[] = [
 ]
 
 function whatsappLink(vehicleName: string): string {
-  return generateWhatsAppLink(`Olá, gostaria de reservar o ${vehicleName}.`)
+  return generateWhatsAppLink('whatsapp.reserve', { vehicle: vehicleName })
 }
 </script>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,14 @@
+import { createI18n } from 'vue-i18n'
+
+import pt from './locales/pt.json'
+import es from './locales/es.json'
+import en from './locales/en.json'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'pt',
+  fallbackLocale: 'pt',
+  messages: { pt, es, en },
+})
+
+export default i18n

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,6 @@
+{
+  "whatsapp": {
+    "reserve": "Hello, I'd like to book the {vehicle}.",
+    "info": "Hello, I'd like more information."
+  }
+}

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1,0 +1,6 @@
+{
+  "whatsapp": {
+    "reserve": "Hola, me gustaría reservar el {vehicle}.",
+    "info": "Hola, me gustaría obtener más información."
+  }
+}

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -1,0 +1,6 @@
+{
+  "whatsapp": {
+    "reserve": "Olá, gostaria de reservar o {vehicle}.",
+    "info": "Olá, gostaria de mais informações."
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import './assets/main.css'
 
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
+import i18n from './i18n'
 
 import App from './App.vue'
 import router from './router'
@@ -10,5 +11,6 @@ const app = createApp(App)
 
 app.use(createPinia())
 app.use(router)
+app.use(i18n)
 
 app.mount('#app')

--- a/src/utils/whatsapp.ts
+++ b/src/utils/whatsapp.ts
@@ -1,6 +1,13 @@
 export const defaultWhatsAppNumber = '554191922590'
 
-export function generateWhatsAppLink(message: string, phone: string = defaultWhatsAppNumber): string {
+import i18n from '@/i18n'
+
+export function generateWhatsAppLink(
+  key: string,
+  params: Record<string, string> = {},
+  phone: string = defaultWhatsAppNumber,
+): string {
+  const message = i18n.global.t(key, params)
   const encodedMessage = encodeURIComponent(message)
   return `https://wa.me/${phone}?text=${encodedMessage}`
 }


### PR DESCRIPTION
## Summary
- install vue-i18n
- configure i18n instance in main.ts
- add translation files for WhatsApp messages
- update WhatsApp helper to use i18n
- update components to use translation keys

## Testing
- `npm run lint` *(fails: jiti library missing)*
- `npm run type-check` *(fails: vue-tsc not found)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b58f66f1c832992e65974ad55bfef