### PR TITLE
Improve logo responsiveness

### DIFF
--- a/src/components/FooterSection.vue
+++ b/src/components/FooterSection.vue
@@ -3,14 +3,14 @@
     <div class="container mx-auto px-6">
       <div class="grid md:grid-cols-4 gap-8">
         <div class="md:col-span-2">
-          <div class="flex items-center space-x-2 sm:space-x-3 mb-4">
+          <div class="flex items-center space-x-1 sm:space-x-2 md:space-x-3 mb-4">
             <img
               src="../assets/MainLogo-sem-fundo.png"
               alt="AJW Executive"
-              class="h-10 w-10 sm:h-12 sm:w-12 flex-shrink-0 object-contain"
+              class="h-8 w-8 sm:h-10 sm:w-10 md:h-12 md:w-12 flex-shrink-0 object-contain"
             />
             <div class="text-white">
-              <h3 class="text-lg sm:text-xl font-bold">AJW</h3>
+              <h3 class="text-base sm:text-lg md:text-xl font-bold">AJW</h3>
               <p class="text-xs sm:text-sm text-amber-400">EXECUTIVE</p>
             </div>
           </div>

--- a/src/components/FooterSection.vue
+++ b/src/components/FooterSection.vue
@@ -3,11 +3,15 @@
     <div class="container mx-auto px-6">
       <div class="grid md:grid-cols-4 gap-8">
         <div class="md:col-span-2">
-          <div class="flex items-center space-x-3 mb-4">
-            <img src="../assets/MainLogo-sem-fundo.png" alt="AJW Executive" class="h-12 w-12" />
+          <div class="flex items-center space-x-2 sm:space-x-3 mb-4">
+            <img
+              src="../assets/MainLogo-sem-fundo.png"
+              alt="AJW Executive"
+              class="h-10 w-10 sm:h-12 sm:w-12 flex-shrink-0 object-contain"
+            />
             <div class="text-white">
-              <h3 class="text-xl font-bold">AJW</h3>
-              <p class="text-sm text-amber-400">EXECUTIVE</p>
+              <h3 class="text-lg sm:text-xl font-bold">AJW</h3>
+              <p class="text-xs sm:text-sm text-amber-400">EXECUTIVE</p>
             </div>
           </div>
           <p class="text-gray-300 mb-4 max-w-md">

--- a/src/components/HeaderSection.vue
+++ b/src/components/HeaderSection.vue
@@ -2,11 +2,15 @@
   <header class="fixed top-0 w-full bg-black/95 backdrop-blur-sm z-50 border-b border-amber-500/20">
     <div class="container mx-auto px-6 py-4">
       <div class="flex items-center justify-between">
-        <div class="flex items-center space-x-3">
-          <img src="../assets/MainLogo-sem-fundo.png" alt="AJW Executive" class="h-12 w-12" />
+        <div class="flex items-center space-x-2 sm:space-x-3">
+          <img
+            src="../assets/MainLogo-sem-fundo.png"
+            alt="AJW Executive"
+            class="h-10 w-10 sm:h-12 sm:w-12 flex-shrink-0 object-contain"
+          />
           <div class="text-white">
-            <h1 class="text-xl font-bold">AJW</h1>
-            <p class="text-sm text-amber-400">EXECUTIVE</p>
+            <h1 class="text-lg sm:text-xl font-bold">AJW</h1>
+            <p class="text-xs sm:text-sm text-amber-400">EXECUTIVE</p>
           </div>
         </div>
 

--- a/src/components/HeaderSection.vue
+++ b/src/components/HeaderSection.vue
@@ -2,14 +2,14 @@
   <header class="fixed top-0 w-full bg-black/95 backdrop-blur-sm z-50 border-b border-amber-500/20">
     <div class="container mx-auto px-6 py-4">
       <div class="flex items-center justify-between">
-        <div class="flex items-center space-x-2 sm:space-x-3">
+        <div class="flex items-center space-x-1 sm:space-x-2 md:space-x-3">
           <img
             src="../assets/MainLogo-sem-fundo.png"
             alt="AJW Executive"
-            class="h-10 w-10 sm:h-12 sm:w-12 flex-shrink-0 object-contain"
+            class="h-8 w-8 sm:h-10 sm:w-10 md:h-12 md:w-12 flex-shrink-0 object-contain"
           />
           <div class="text-white">
-            <h1 class="text-lg sm:text-xl font-bold">AJW</h1>
+            <h1 class="text-base sm:text-lg md:text-xl font-bold">AJW</h1>
             <p class="text-xs sm:text-sm text-amber-400">EXECUTIVE</p>
           </div>
         </div>

--- a/src/components/HeroSection.vue
+++ b/src/components/HeroSection.vue
@@ -9,8 +9,11 @@
     <div class="container mx-auto px-6 relative z-10">
       <div class="max-w-4xl mx-auto text-center">
         <div class="mb-8">
-          <img src="../assets/MainLogo-sem-fundo.png" alt="AJW Executive"
-            class="h-65 w-65 mx-auto mb-6 filter drop-shadow-2xl" />
+          <img
+            src="../assets/MainLogo-sem-fundo.png"
+            alt="AJW Executive"
+            class="h-40 w-40 md:h-56 md:w-56 mx-auto mb-6 filter drop-shadow-2xl object-contain"
+          />
         </div>
 
         <h1 class="text-5xl md:text-7xl font-bold text-white mb-6 leading-tight">

--- a/src/components/HeroSection.vue
+++ b/src/components/HeroSection.vue
@@ -12,7 +12,7 @@
           <img
             src="../assets/MainLogo-sem-fundo.png"
             alt="AJW Executive"
-            class="h-40 w-40 md:h-56 md:w-56 mx-auto mb-6 filter drop-shadow-2xl object-contain"
+            class="h-32 w-32 sm:h-40 sm:w-40 md:h-56 md:w-56 mx-auto mb-6 filter drop-shadow-2xl object-contain"
           />
         </div>
 


### PR DESCRIPTION
## Summary
- adjust header logo sizing for small screens
- make hero and footer logos responsive as well

## Testing
- `npm run lint` *(fails: The 'jiti' library is required)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f5d5d37008329b2a63ba8ef2cb0a0