### PR TITLE
Add floating WhatsApp info button

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { RouterView } from 'vue-router'
 import HeaderSection from '@/components/HeaderSection.vue'
+import WhatsAppFloatingButton from '@/components/WhatsAppFloatingButton.vue'
 </script>
 
 <template>
   <HeaderSection />
   <RouterView />
+  <WhatsAppFloatingButton />
 </template>
 
 <style scoped></style>

--- a/src/components/WhatsAppFloatingButton.vue
+++ b/src/components/WhatsAppFloatingButton.vue
@@ -1,0 +1,21 @@
+<template>
+  <a
+    :href="whatsappLink()"
+    target="_blank"
+    rel="noopener noreferrer"
+    class="fixed bottom-6 right-6 z-50 flex items-center gap-2 bg-green-500 text-white px-4 py-3 rounded-full shadow-lg hover:bg-green-600"
+  >
+    <img src="@/assets/social-media/WhatsApp.svg.png" alt="WhatsApp" class="w-6 h-6" />
+    <span class="font-semibold">Info</span>
+  </a>
+</template>
+
+<script setup lang="ts">
+import { generateWhatsAppLink } from '@/utils/whatsapp'
+
+function whatsappLink(): string {
+  return generateWhatsAppLink('whatsapp.info')
+}
+</script>
+
+<style scoped></style>


### PR DESCRIPTION
## Summary
- create `WhatsAppFloatingButton.vue`
- include the floating button in the app layout

## Testing
- `npm run lint` *(fails: jiti missing)*
- `npm run test:unit` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861429cfe188329b5d843fc9cf76d2f