### PR TITLE
feat: add google reviews section

### DIFF
--- a/src/components/ContactSection.vue
+++ b/src/components/ContactSection.vue
@@ -29,7 +29,7 @@
             <h3 class="text-2xl font-bold text-white mb-4">{{ t('contactSection.instagram') }}</h3>
           </a>
 
-          <a href="https://t.me/agenciaajwexecutive" target="_blank" rel="noopener noreferrer"
+          <a href="https://t.me/+5541995086935" target="_blank" rel="noopener noreferrer"
             class="block bg-gray-900/50 backdrop-blur-sm border border-amber-500/20 rounded-2xl p-8 text-center hover:border-amber-500/50 transition-all transform hover:scale-105">
             <div class="w-16 h-16 bg-blue-500 rounded-full flex items-center justify-center mx-auto mb-6">
               <img src="@/assets/social-media/Telegram_logo.svg.png" alt="Telegram" class="w-12 h-12" />

--- a/src/components/GoogleReviewsSection.vue
+++ b/src/components/GoogleReviewsSection.vue
@@ -1,0 +1,106 @@
+<template>
+  <section id="reviews" class="py-20 bg-black">
+    <div class="container mx-auto px-6">
+      <div class="text-center max-w-3xl mx-auto mb-16">
+        <h2 class="text-4xl md:text-5xl font-bold text-white mb-4">
+          {{ t('reviewsSection.title') }}
+        </h2>
+        <p class="text-xl text-gray-300">
+          {{ t('reviewsSection.subtitle') }}
+        </p>
+      </div>
+
+      <div class="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+        <article
+          v-for="review in displayedReviews"
+          :key="review.name"
+          class="bg-gray-900/80 backdrop-blur-sm border border-amber-500/20 rounded-2xl p-8 flex flex-col h-full"
+        >
+          <header class="flex items-center mb-6">
+            <div
+              class="w-12 h-12 rounded-full bg-amber-500 text-black font-bold flex items-center justify-center text-lg"
+            >
+              {{ getInitials(review.name) }}
+            </div>
+            <div class="ml-4">
+              <h3 class="text-white font-semibold">{{ review.name }}</h3>
+              <p class="text-sm text-gray-400">{{ review.meta }}</p>
+            </div>
+          </header>
+
+          <p class="text-gray-300 leading-relaxed flex-1">
+            “{{ review.comment }}”
+          </p>
+
+          <footer class="mt-6 flex items-center text-amber-400">
+            <span v-for="n in 5" :key="n" class="mr-1">★</span>
+            <span class="text-sm text-gray-400 ml-2">Google Reviews</span>
+          </footer>
+        </article>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+interface Review {
+  name: string
+  meta: string
+  comment: string
+}
+
+const { t } = useI18n()
+
+const reviews: Review[] = [
+  {
+    name: 'Patrick Simões',
+    meta: '14 avaliações',
+    comment:
+      'O motorista dirigia muito bem, o carro estava limpo e a viagem foi muito tranquila. Foi, sem dúvida, o melhor transfer que já tive.'
+  },
+  {
+    name: 'Rubens Murilo Marcolino',
+    meta: '2 avaliações · há 1 mês',
+    comment:
+      'Motorista prestativo, boa dirigibilidade, veículo em bom estado, serviço realmente de qualidade. Precisei ir do aeroporto até o hotel em Curitiba.'
+  },
+  {
+    name: 'João Dutra',
+    meta: '4 avaliações · 1 foto · há 1 mês',
+    comment:
+      'Motorista bem tranquilo, viagem no conforto e segurança de quem faz o serviço com excelência. Fui do aeroporto para o centro de Curitiba.'
+  },
+  {
+    name: 'Jonatha Rabelo',
+    meta: '1 avaliação · há 1 mês',
+    comment: 'Ótimo atendimento, super recomendo. Carro impecável.'
+  },
+  {
+    name: 'Aleff Max',
+    meta: '3 avaliações · há 1 mês',
+    comment: 'Serviço muito bom, viagem impecável e tranquila.'
+  }
+]
+
+const displayedReviews = computed(() => {
+  const available = reviews.filter((review) => review.comment.trim().length > 0)
+  const shuffled = [...available]
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]]
+  }
+  return shuffled.slice(0, 3)
+})
+
+function getInitials(name: string): string {
+  return name
+    .split(' ')
+    .filter(Boolean)
+    .map((part) => part[0]?.toUpperCase() ?? '')
+    .slice(0, 2)
+    .join('')
+}
+</script>

--- a/src/components/GoogleReviewsSection.vue
+++ b/src/components/GoogleReviewsSection.vue
@@ -52,41 +52,19 @@ interface Review {
   comment: string
 }
 
-const { t } = useI18n()
+const { t, tm } = useI18n()
 
-const reviews: Review[] = [
-  {
-    name: 'Patrick Simões',
-    meta: '14 avaliações',
-    comment:
-      'O motorista dirigia muito bem, o carro estava limpo e a viagem foi muito tranquila. Foi, sem dúvida, o melhor transfer que já tive.'
-  },
-  {
-    name: 'Rubens Murilo Marcolino',
-    meta: '2 avaliações · há 1 mês',
-    comment:
-      'Motorista prestativo, boa dirigibilidade, veículo em bom estado, serviço realmente de qualidade. Precisei ir do aeroporto até o hotel em Curitiba.'
-  },
-  {
-    name: 'João Dutra',
-    meta: '4 avaliações · 1 foto · há 1 mês',
-    comment:
-      'Motorista bem tranquilo, viagem no conforto e segurança de quem faz o serviço com excelência. Fui do aeroporto para o centro de Curitiba.'
-  },
-  {
-    name: 'Jonatha Rabelo',
-    meta: '1 avaliação · há 1 mês',
-    comment: 'Ótimo atendimento, super recomendo. Carro impecável.'
-  },
-  {
-    name: 'Aleff Max',
-    meta: '3 avaliações · há 1 mês',
-    comment: 'Serviço muito bom, viagem impecável e tranquila.'
+const localizedReviews = computed<Review[]>(() => {
+  const reviews = tm('reviewsSection.reviews') as Review[] | undefined
+  if (!Array.isArray(reviews)) {
+    return []
   }
-]
+
+  return reviews.filter((review) => Boolean(review.comment?.trim().length))
+})
 
 const displayedReviews = computed(() => {
-  const available = reviews.filter((review) => review.comment.trim().length > 0)
+  const available = localizedReviews.value
   const shuffled = [...available]
   for (let i = shuffled.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1))

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -136,6 +136,10 @@
     },
     "imageAlt": "{company} Professionalism"
   },
+  "reviewsSection": {
+    "title": "Google Reviews",
+    "subtitle": "See what our customers say about their experience with AJW Executive."
+  },
   "contactSection": {
     "title": "Contact Us",
     "subtitle": "Get in touch through our social networks",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -138,7 +138,34 @@
   },
   "reviewsSection": {
     "title": "Google Reviews",
-    "subtitle": "See what our customers say about their experience with AJW Executive."
+    "subtitle": "See what our customers say about their experience with AJW Executive.",
+    "reviews": [
+      {
+        "name": "Patrick Simões",
+        "meta": "14 reviews",
+        "comment": "The driver drove very well, the car was clean, and the trip was very smooth. Without a doubt, it was the best transfer I've ever had."
+      },
+      {
+        "name": "Rubens Murilo Marcolino",
+        "meta": "2 reviews · 1 month ago",
+        "comment": "Helpful driver, good handling, vehicle in good condition, truly quality service. I needed to go from the airport to the hotel in Curitiba."
+      },
+      {
+        "name": "João Dutra",
+        "meta": "4 reviews · 1 photo · 1 month ago",
+        "comment": "Very calm driver, a trip with the comfort and safety of someone who provides excellent service. I went from the airport to downtown Curitiba."
+      },
+      {
+        "name": "Jonatha Rabelo",
+        "meta": "1 review · 1 month ago",
+        "comment": "Great service, highly recommend. Impeccable car."
+      },
+      {
+        "name": "Aleff Max",
+        "meta": "3 reviews · 1 month ago",
+        "comment": "Very good service, flawless and smooth trip."
+      }
+    ]
   },
   "contactSection": {
     "title": "Contact Us",
@@ -157,6 +184,6 @@
       "events": "Special Events"
     },
     "contactTitle": "Contact",
-    "rights": "© {year} <a href=\"https://github.com/PatrickSimoes\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"text-amber-400 ml-2\">Patrick Simões</a>. All rights reserved."
+    "rights": "© {year} <a href=\"https://www.linkedin.com/in/patrick-simoes/\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"text-amber-400 ml-2\">Patrick Simões</a>. All rights reserved."
   }
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -136,6 +136,10 @@
     },
     "imageAlt": "Profesionalismo {company}"
   },
+  "reviewsSection": {
+    "title": "Reseñas en Google",
+    "subtitle": "Descubre lo que nuestros clientes dicen sobre su experiencia con AJW Executive."
+  },
   "contactSection": {
     "title": "Contacto",
     "subtitle": "Ponte en contacto con nosotros a través de nuestras redes sociales",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -138,7 +138,34 @@
   },
   "reviewsSection": {
     "title": "Reseñas en Google",
-    "subtitle": "Descubre lo que nuestros clientes dicen sobre su experiencia con AJW Executive."
+    "subtitle": "Descubre lo que nuestros clientes dicen sobre su experiencia con AJW Executive.",
+    "reviews": [
+      {
+        "name": "Patrick Simões",
+        "meta": "14 reseñas",
+        "comment": "El conductor manejaba muy bien, el auto estaba limpio y el viaje fue muy tranquilo. Sin duda fue el mejor transfer que he tenido."
+      },
+      {
+        "name": "Rubens Murilo Marcolino",
+        "meta": "2 reseñas · hace 1 mes",
+        "comment": "Conductor servicial, buena conducción, vehículo en buen estado, un servicio realmente de calidad. Necesitaba ir del aeropuerto al hotel en Curitiba."
+      },
+      {
+        "name": "João Dutra",
+        "meta": "4 reseñas · 1 foto · hace 1 mes",
+        "comment": "Conductor muy tranquilo, viaje con la comodidad y seguridad de quien realiza el servicio con excelencia. Fui del aeropuerto al centro de Curitiba."
+      },
+      {
+        "name": "Jonatha Rabelo",
+        "meta": "1 reseña · hace 1 mes",
+        "comment": "Excelente atención, lo recomiendo mucho. Auto impecable."
+      },
+      {
+        "name": "Aleff Max",
+        "meta": "3 reseñas · hace 1 mes",
+        "comment": "Servicio muy bueno, viaje impecable y tranquilo."
+      }
+    ]
   },
   "contactSection": {
     "title": "Contacto",
@@ -157,6 +184,6 @@
       "events": "Eventos Especiales"
     },
     "contactTitle": "Contacto",
-    "rights": "© {year} <a href=\"https://github.com/PatrickSimoes\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"text-amber-400 ml-2\">Patrick Simões</a>. Todos los derechos reservados."
+    "rights": "© {year} <a href=\"https://www.linkedin.com/in/patrick-simoes/\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"text-amber-400 ml-2\">Patrick Simões</a>. Todos los derechos reservados."
   }
 }

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -136,6 +136,10 @@
     },
     "imageAlt": "Profissionalismo {company}"
   },
+  "reviewsSection": {
+    "title": "Avaliações no Google",
+    "subtitle": "Veja o que nossos clientes dizem sobre a experiência com a AJW Executive."
+  },
   "contactSection": {
     "title": "Entre em Contato",
     "subtitle": "Entre em contato conosco através das nossas redes sociais",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -138,7 +138,34 @@
   },
   "reviewsSection": {
     "title": "Avaliações no Google",
-    "subtitle": "Veja o que nossos clientes dizem sobre a experiência com a AJW Executive."
+    "subtitle": "Veja o que nossos clientes dizem sobre a experiência com a AJW Executive.",
+    "reviews": [
+      {
+        "name": "Patrick Simões",
+        "meta": "14 avaliações",
+        "comment": "O motorista dirigia muito bem, o carro estava limpo e a viagem foi muito tranquila. Foi, sem dúvida, o melhor transfer que já tive."
+      },
+      {
+        "name": "Rubens Murilo Marcolino",
+        "meta": "2 avaliações · há 1 mês",
+        "comment": "Motorista prestativo, boa dirigibilidade, veículo em bom estado, serviço realmente de qualidade. Precisei ir do aeroporto até o hotel em Curitiba."
+      },
+      {
+        "name": "João Dutra",
+        "meta": "4 avaliações · 1 foto · há 1 mês",
+        "comment": "Motorista bem tranquilo, viagem no conforto e segurança de quem faz o serviço com excelência. Fui do aeroporto para o centro de Curitiba."
+      },
+      {
+        "name": "Jonatha Rabelo",
+        "meta": "1 avaliação · há 1 mês",
+        "comment": "Ótimo atendimento, super recomendo. Carro impecável."
+      },
+      {
+        "name": "Aleff Max",
+        "meta": "3 avaliações · há 1 mês",
+        "comment": "Serviço muito bom, viagem impecável e tranquila."
+      }
+    ]
   },
   "contactSection": {
     "title": "Entre em Contato",
@@ -157,6 +184,6 @@
       "events": "Eventos Especiais"
     },
     "contactTitle": "Contato",
-    "rights": "© {year} <a href=\"https://github.com/PatrickSimoes\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"text-amber-400 ml-2\">Patrick Simões</a>. Todos os direitos reservados."
+    "rights": "© {year} <a href=\"https://www.linkedin.com/in/patrick-simoes/\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"text-amber-400 ml-2\">Patrick Simões</a>. Todos os direitos reservados."
   }
 }

--- a/src/views/LandingPage.vue
+++ b/src/views/LandingPage.vue
@@ -4,6 +4,7 @@
     <ServicesSection />
     <FleetSection />
     <AboutSection />
+    <GoogleReviewsSection />
     <ContactSection />
     <FooterSection />
   </main>
@@ -14,6 +15,7 @@ import HeroSection from '@/components/HeroSection.vue'
 import ServicesSection from '@/components/ServicesSection.vue'
 import FleetSection from '@/components/FleetSection.vue'
 import AboutSection from '@/components/AboutSection.vue'
+import GoogleReviewsSection from '@/components/GoogleReviewsSection.vue'
 import ContactSection from '@/components/ContactSection.vue'
 import FooterSection from '@/components/FooterSection.vue'
 </script>


### PR DESCRIPTION
## Summary
- add a Google reviews section that randomly rotates through mock testimonials with text
- provide localized copy for the new section in Portuguese, English, and Spanish
- include the reviews block on the landing page layout

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918828d470c8329a4debb81556dd04d)